### PR TITLE
Add bin/wright

### DIFF
--- a/bin/wright
+++ b/bin/wright
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+require 'wright/cli'
+
+wright = Wright::CLI.new
+wright.run(ARGV)

--- a/lib/wright/cli.rb
+++ b/lib/wright/cli.rb
@@ -1,6 +1,8 @@
 require 'optparse'
 require 'wright'
 
+$main = self
+
 module Wright
   class CLI
     # @todo Show usage if no arguments given
@@ -15,6 +17,7 @@ module Wright
 
       ARGV.shift
 
+      $main.extend Wright::DSL
       load arguments.first unless arguments.empty?
     end
   end

--- a/lib/wright/cli.rb
+++ b/lib/wright/cli.rb
@@ -5,23 +5,34 @@ $main = self
 
 module Wright
   class CLI
-    # @todo Show usage if no arguments given
+    def initialize
+      @commands = []
+    end
+
     def run(argv)
       @parser = OptionParser.new do |opts|
+        opts.on('-e COMMAND', 'Run COMMAND') do |e|
+          @commands << e
+        end
+
         opts.on_tail('-v', '--version', 'Show wright version') do
           puts "wright version #{Wright::VERSION}"
           return
         end
       end
 
-      # use OptionParser#order instead of #parse so CLI#run does not
+      # use OptionParser#order! instead of #parse! so CLI#run does not
       # consume --arguments passed to wright scripts
-      arguments = @parser.order(argv)
-
-      ARGV.shift
+      arguments = @parser.order!(argv)
 
       $main.extend Wright::DSL
-      load arguments.first unless arguments.empty?
+
+      if @commands.empty?
+        script = arguments.shift
+        load script if script
+      else
+        eval(@commands.join("\n"), $main.send(:binding), '<main>', 1)
+      end
     end
   end
 end

--- a/lib/wright/cli.rb
+++ b/lib/wright/cli.rb
@@ -1,0 +1,8 @@
+require 'wright'
+
+module Wright
+  class CLI
+    def run(argv)
+    end
+  end
+end

--- a/lib/wright/cli.rb
+++ b/lib/wright/cli.rb
@@ -1,8 +1,16 @@
+require 'optparse'
 require 'wright'
 
 module Wright
   class CLI
     def run(argv)
+      @parser = OptionParser.new do |opts|
+        opts.on_tail('-v', '--version', 'Show wright version') do
+          puts "wright version #{Wright::VERSION}"
+          return
+        end
+      end
+      @parser.parse!(argv)
     end
   end
 end

--- a/lib/wright/cli.rb
+++ b/lib/wright/cli.rb
@@ -7,9 +7,6 @@ module Wright
   class CLI
     def initialize
       @commands = []
-    end
-
-    def run(argv)
       @parser = OptionParser.new do |opts|
         opts.on('-e COMMAND', 'Run COMMAND') do |e|
           @commands << e
@@ -17,13 +14,14 @@ module Wright
 
         opts.on_tail('-v', '--version', 'Show wright version') do
           puts "wright version #{Wright::VERSION}"
-          return
+          @quit = true
         end
       end
+    end
 
-      # use OptionParser#order! instead of #parse! so CLI#run does not
-      # consume --arguments passed to wright scripts
-      arguments = @parser.order!(argv)
+    def run(argv)
+      arguments = parse(argv)
+      return if @quit
 
       $main.extend Wright::DSL
 
@@ -33,6 +31,16 @@ module Wright
       else
         eval(@commands.join("\n"), $main.send(:binding), '<main>', 1)
       end
+    end
+
+    private
+
+    attr_reader :commands
+
+    def parse(argv)
+      # use OptionParser#order! instead of #parse! so CLI#run does not
+      # consume --arguments passed to wright scripts
+      @parser.order!(argv)
     end
   end
 end

--- a/lib/wright/cli.rb
+++ b/lib/wright/cli.rb
@@ -13,7 +13,10 @@ module Wright
           return
         end
       end
-      arguments = @parser.parse(argv)
+
+      # use OptionParser#order instead of #parse so CLI#run does not
+      # consume --arguments passed to wright scripts
+      arguments = @parser.order(argv)
 
       ARGV.shift
 

--- a/lib/wright/cli.rb
+++ b/lib/wright/cli.rb
@@ -3,6 +3,7 @@ require 'wright'
 
 module Wright
   class CLI
+    # @todo Show usage if no arguments given
     def run(argv)
       @parser = OptionParser.new do |opts|
         opts.on_tail('-v', '--version', 'Show wright version') do
@@ -10,7 +11,11 @@ module Wright
           return
         end
       end
-      @parser.parse!(argv)
+      arguments = @parser.parse(argv)
+
+      ARGV.shift
+
+      load arguments.first unless arguments.empty?
     end
   end
 end

--- a/spec/cli/shebang.rb
+++ b/spec/cli/shebang.rb
@@ -1,0 +1,3 @@
+print 'loaded shebang.rb'
+#class WrightDSLMissing < StandardError; end
+#fail WrightDSLMissing unless respond_to? :package

--- a/spec/cli/shebang.rb
+++ b/spec/cli/shebang.rb
@@ -1,3 +1,3 @@
 print 'loaded shebang.rb'
-#class WrightDSLMissing < StandardError; end
-#fail WrightDSLMissing unless respond_to? :package
+class WrightDSLMissing < StandardError; end
+fail WrightDSLMissing unless respond_to? :package

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,0 +1,26 @@
+require_relative 'spec_helper'
+
+require 'wright/cli'
+
+describe Wright::CLI do
+  before(:each) do
+    @cli = CLI.new
+    @cli_dir = File.expand_path('../cli', __FILE__)
+  end
+
+  describe '#run' do
+    it 'parses --version' do
+      argv = '--version'
+      expected = "wright version #{VERSION}\n"
+
+      -> { @cli.run(argv) }.must_output expected
+    end
+
+    it 'loads files' do
+      expected = 'loaded shebang.rb'
+      lambda do
+        @cli.run(File.join @cli_dir, 'shebang.rb')
+      end.must_output expected
+    end
+  end
+end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -9,6 +9,17 @@ describe Wright::CLI do
     @cli_dir = File.expand_path('../cli', __FILE__)
   end
 
+  describe '#parse' do
+    before(:each) { Wright::CLI.send(:public, :parse) }
+    after(:each) { Wright::CLI.send(:private, :parse) }
+
+    it 'parses -e COMMAND' do
+      argv = %w[-e foo -e bar -- --baz]
+      @cli.parse(argv).must_equal %w[--baz]
+      @cli.send(:commands).must_equal %w[foo bar]
+    end
+  end
+
   describe '#run' do
     it 'parses --version' do
       argv = ['--version']
@@ -21,6 +32,11 @@ describe Wright::CLI do
       argv = [File.join(@cli_dir, 'shebang.rb')]
       expected = 'loaded shebang.rb'
       -> { @cli.run(argv) }.must_output expected
+    end
+
+    it 'evals commands' do
+      argv = ['-e print :foo']
+      -> { @cli.run(argv) }.must_output 'foo'
     end
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -11,17 +11,16 @@ describe Wright::CLI do
 
   describe '#run' do
     it 'parses --version' do
-      argv = '--version'
+      argv = ['--version']
       expected = "wright version #{Wright::VERSION}\n"
 
       -> { @cli.run(argv) }.must_output expected
     end
 
     it 'loads files' do
+      argv = [File.join(@cli_dir, 'shebang.rb')]
       expected = 'loaded shebang.rb'
-      lambda do
-        @cli.run(File.join @cli_dir, 'shebang.rb')
-      end.must_output expected
+      -> { @cli.run(argv) }.must_output expected
     end
   end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,17 +1,18 @@
 require_relative 'spec_helper'
 
 require 'wright/cli'
+require 'wright/version'
 
 describe Wright::CLI do
   before(:each) do
-    @cli = CLI.new
+    @cli = Wright::CLI.new
     @cli_dir = File.expand_path('../cli', __FILE__)
   end
 
   describe '#run' do
     it 'parses --version' do
       argv = '--version'
-      expected = "wright version #{VERSION}\n"
+      expected = "wright version #{Wright::VERSION}\n"
 
       -> { @cli.run(argv) }.must_output expected
     end


### PR DESCRIPTION
This pull request adds a binary that can be used to execute wright scripts and is also usable as an interpreter in standalone scripts such as this one:

``` ruby
#!/path/to/wright
symlink('/tmp/foo') { |s| s.to = '/tmp/bar' }
```
